### PR TITLE
add configuration option to increase timeout for initial generation

### DIFF
--- a/.changeset/unlucky-bags-relate.md
+++ b/.changeset/unlucky-bags-relate.md
@@ -1,0 +1,5 @@
+---
+"rollup-plugin-typed-gql": minor
+---
+
+Add new optional configuration parameter to allow longer timeout for initial schema generation

--- a/README.md
+++ b/README.md
@@ -99,5 +99,9 @@ typedGql({
    * Base directory to search for files.
    */
   baseDir: process.cwd(),
+  /**
+   * Time to complete initial generation
+   */
+  startupTimeout: 2000,
 });
 ```

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -17,6 +17,8 @@ import { loadSchema, noop, promiseWithTimeout } from "./helpers.js";
  * @property {string} [baseDir]
  * Base directory to search for files. Defaults to the current working
  * directory (`process.cwd()`).
+ * @property {number} [startupTimeout]
+ * Time to complete initial generation. Default 2000 (ms)
  */
 
 /**
@@ -82,7 +84,7 @@ export default function typedGql(options) {
 			try {
 				await promiseWithTimeout(
 					initialGeneration,
-					2000,
+					options.startupTimeout ?? 2000,
 					"Timed out while generating type declarations for GraphQL queries."
 				);
 			} catch (err) {


### PR DESCRIPTION
Currently, initial generation times out after 2000ms. For big schemas, this can be too strict.

We want to keep the default timeout to avoid scanning entire file systems in cases of misconfiguration. However, it should be possible to opt-in to increase the timeout. This PR introduces a new configuration option `startupTimeout` with default value of `2000` to address this issue.