### PR TITLE
Only watch the search folder

### DIFF
--- a/.changeset/sweet-bottles-kiss.md
+++ b/.changeset/sweet-bottles-kiss.md
@@ -1,0 +1,5 @@
+---
+"rollup-plugin-typed-gql": patch
+---
+
+Fix bug where plugin hangs during concurrent builds of a package.


### PR DESCRIPTION
The search folder is the only folder that should be watched, else the `watcher.on(ready)` event might take long to fire in case build files are being generated concurrently.