### PR TITLE
feat: add buildOnce for one-time type generation without file watching

### DIFF
--- a/.changeset/kind-ways-behave.md
+++ b/.changeset/kind-ways-behave.md
@@ -1,0 +1,5 @@
+---
+"rollup-plugin-typed-gql": minor
+---
+
+Adds a new `buildOnce` function for one-time type generation without continuously watching the file system for changes


### PR DESCRIPTION
Adds a new function for situations when you don't want to wait for `startupTimeout` before returning